### PR TITLE
WIP: blank passphrases after using them for security

### DIFF
--- a/locutus.sh
+++ b/locutus.sh
@@ -62,10 +62,6 @@ excluded=$excluded_patterns", "$excluded_folders
 excluded=${excluded//\,/}
 echo $excluded | tr " " "\n" > ./.excluded.tmp
 
-set -a
-source <(gpg -qd $password_file_location)
-set +a
-
 expect_path=$(which expect)
 if [ "$expect_path" = "expect not found" ]
 then
@@ -215,6 +211,10 @@ else
 fi
 rm -rf ./.excluded.tmp
 
+set -a
+source <(gpg -qd $password_file_location)
+set +a
+
 # Backup Gmail using gmvault
 expect <<- DONE
     set timeout -1
@@ -222,8 +222,8 @@ expect <<- DONE
     match_max 100000
     expect -re {Please enter gmail password for }
     send "$GOOGLE_PASSPHRASE"
+    GOOGLE_PASSPHRASE=""
     send -- "\r"
-    setenv GOOGLE_PASSPHRASE ""
     expect eof
 DONE
 
@@ -234,8 +234,8 @@ expect <<- DONE
     match_max 100000
     expect -re {\[0m\[sudo\] password for }
     send "$SUDO_PASSPHRASE"
+    SUDO_PASSPHRASE=""
     send -- "\r"
-    setenv SUDO_PASSPHRASE ""
     expect eof
 DONE
 
@@ -251,7 +251,6 @@ echo "Copying........."
 #Upload to mega.nz
 echo "Uploading......."
 megasync
-MEGA_PASSPHRASE = ""
 
 kill $(pgrep megasync)
 find -iname "*.tmp" -delete

--- a/locutus.sh
+++ b/locutus.sh
@@ -223,6 +223,7 @@ expect <<- DONE
     expect -re {Please enter gmail password for }
     send "$GOOGLE_PASSPHRASE"
     send -- "\r"
+    setenv GOOGLE_PASSPHRASE ""
     expect eof
 DONE
 
@@ -234,6 +235,7 @@ expect <<- DONE
     expect -re {\[0m\[sudo\] password for }
     send "$SUDO_PASSPHRASE"
     send -- "\r"
+    setenv SUDO_PASSPHRASE ""
     expect eof
 DONE
 
@@ -249,6 +251,7 @@ echo "Copying........."
 #Upload to mega.nz
 echo "Uploading......."
 megasync
+MEGA_PASSPHRASE = ""
 
 kill $(pgrep megasync)
 find -iname "*.tmp" -delete


### PR DESCRIPTION
This is just an idea. Figured why not blank passwords as soon as they are no longer necessary, since backing up gmail etc will take a long time (according to what I've heard from you), so as it is now the variable would just be sitting there the whole time. Not sure how to do it from within expect though so just wrote some 'psuedocode'-ish lines there for now.